### PR TITLE
Fixes for gtk+3 / vte-2.91

### DIFF
--- a/doc/reference/terminal.html
+++ b/doc/reference/terminal.html
@@ -122,11 +122,11 @@ A <a href="http://developer.gnome.org/vte/unstable/VteTerminal.html">VteTerminal
 <tr><td class="wiki"> hscrollbar-policy </td><td class="wiki"> Policy for the horizontal scrollbar </td><td class="wiki"> <code>0</code>, <code>1</code>, <code>2</code> (always, automatic, never) </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> vscrollbar-policy </td><td class="wiki"> Policy for the vertical scrollbar </td><td class="wiki"> <code>0</code>, <code>1</code>, <code>2</code> (always, automatic, never) </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> font-name </td><td class="wiki"> Font description </td><td class="wiki"> Example: <code>Monospace Bold 14</code> </td><td class="wiki"> </td></tr>
-<tr><td class="wiki"> background-tint-color<sup><a href="#note1">[1]</a></sup> </td><td class="wiki"> Background tint colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
+<tr><td class="wiki"> background-tint-color<sup><a href="#note1">[1]</a><a href="#note2">[2]</a></sup> </td><td class="wiki"> Background tint colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> text-background-color </td><td class="wiki"> Text background colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> text-foreground-color </td><td class="wiki"> Text foreground colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> bold-foreground-color </td><td class="wiki"> Bold text foreground colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
-<tr><td class="wiki"> dim-foreground-color </td><td class="wiki"> Dim text foreground colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
+<tr><td class="wiki"> dim-foreground-color<sup><a href="#note2">[2]</a></sup> </td><td class="wiki"> Dim text foreground colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> cursor-background-color </td><td class="wiki"> Cursor background colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> highlight-background-color </td><td class="wiki"> Highlighted text background colour </td><td class="wiki"> A standard name,  <i>#rgb </i> or  <i>#rrggbb </i> </td><td class="wiki"> </td></tr>
 <tr><td class="wiki"> argv? </td><td class="wiki"> Arguments starting at argv0 (command) </td><td class="wiki"> Example: <code>/bin/sh</code> </td><td class="wiki"> </td></tr>
@@ -218,6 +218,7 @@ A <a href="http://developer.gnome.org/vte/unstable/VteTerminal.html">VteTerminal
 <h2> Notes </h2>
 
 <p><a name="note1"></a>1. There exists an equivalently named "<a href="http://developer.gnome.org/vte/unstable/VteTerminal.html#VteTerminal--background-tint-color">background-tint-color</a>" VTE property but it doesn't accept strings so it's converted by Gtkdialog.</p>
+<p><a name="note2"></a>2. The "background-tint-color" and "dim-foreground-color" tag attributes are not permitted when using VTE >= 0.38 (which is the case for gtk3).</p>
 
 <p>This is a non-mandatory widget that requires <a href="http://ftp.gnome.org/pub/gnome/sources/vte/">libvte</a> support be built into Gtkdialog at compile time.</p>
 

--- a/examples/terminal/terminal
+++ b/examples/terminal/terminal
@@ -73,7 +73,6 @@ MAIN_DIALOG='
 				cursor-shape="2"
 				background-transparent="true"
 				background-saturation="0.2"
-				background-tint-color="#223"
 				text-foreground-color="#fff">
 				<variable>vte2</variable>
 				<input file>'"$TMPDIR"'/feed</input>

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -722,7 +722,7 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 	glong             char_height;
 	glong             char_width;
 #if HAVE_VTE
-#if 0 //#if VTE_CHECK_VERSION(0,26,0)
+#if VTE_CHECK_VERSION(0,26,0)
 	GtkBorder         inner_border;
 #endif
 #endif
@@ -777,7 +777,7 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 			 * but GLib is telling me that 'VteTerminal' has no property
 			 * named 'inner-border' so I have to go with the deprecated
 			 * vte_terminal_get_padding() */
-#if 0 //#if VTE_CHECK_VERSION(0,26,0)
+#if VTE_CHECK_VERSION(0,26,0)
 			g_object_get(G_OBJECT(widget), "inner-border", &inner_border, NULL);
 #ifdef DEBUG_CONTENT
 			fprintf(stderr, "%s(): inner_border.left=%i inner_border.right=%i \
@@ -801,7 +801,12 @@ inner_border.top=%i inner_border.bottom=%i\n", __func__, inner_border.left,
 			if (width == -1) width = 80 * char_width + xpad;
 			if (height == -1) height = 25 * char_height + ypad;
 			/* Set the size */
+#if GTK_CHECK_VERSION(2,2,0)
+			gtk_widget_set_size_request(scrolledwindow, width, height);
+#else
 			gtk_widget_set_usize(scrolledwindow, width, height);
+#endif
+
 			/* Pack the widget */
 			gtk_container_add(GTK_CONTAINER(scrolledwindow), widget);
 			break;

--- a/src/widget_terminal.c
+++ b/src/widget_terminal.c
@@ -84,6 +84,10 @@ GtkWidget *widget_terminal_create(
 	gint              width = -1, height = -1;
 #endif
 
+#if VTE_CHECK_VERSION(0,38,0)
+	PangoFontDescription *fontdesc;
+#endif
+
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Entering.\n", __func__);
 #endif
@@ -110,10 +114,16 @@ GtkWidget *widget_terminal_create(
 		 * widget_set_tag_attributes() will try to set it later */
 		strcpy(tagattribute, "font-desc");
 		if ((value = get_tag_attribute(attr, tagattribute))) {
+#if VTE_CHECK_VERSION(0,38,0)
+			fontdesc = pango_font_description_from_string (value);
+			vte_terminal_set_font(VTE_TERMINAL(widget), fontdesc);
+#else
 			vte_terminal_set_font_from_string(VTE_TERMINAL(widget), value);
+#endif
 			kill_tag_attribute(attr, tagattribute);
 		}
 
+#if ! VTE_CHECK_VERSION(0,38,0)
 		/* Again, "background-tint-color" requires a pointer to a
 		 * GdkColor struct but we can convert a string like "#ff00ff" */
 		strcpy(tagattribute, "background-tint-color");
@@ -129,10 +139,16 @@ GtkWidget *widget_terminal_create(
 			}
 			kill_tag_attribute(attr, tagattribute);
 		}
+#endif
 
 		/* Get custom tag attribute "font-name" */
 		if ((value = get_tag_attribute(attr, "font-name"))) {
+#if VTE_CHECK_VERSION(0,38,0)
+			fontdesc = pango_font_description_from_string (value);
+			vte_terminal_set_font(VTE_TERMINAL(widget), fontdesc);
+#else
 			vte_terminal_set_font_from_string(VTE_TERMINAL(widget), value);
+#endif
 		}
 
 		/* Get custom tag attribute "text-background-color" */
@@ -174,6 +190,7 @@ GtkWidget *widget_terminal_create(
 			}
 		}
 
+#if ! VTE_CHECK_VERSION(0,38,0)
 		/* Get custom tag attribute "dim-foreground-color" */
 		if ((value = get_tag_attribute(attr, "dim-foreground-color"))) {
 			/* Parse the RGB value to create the necessary GdkColor.
@@ -186,6 +203,7 @@ GtkWidget *widget_terminal_create(
 				vte_terminal_set_color_dim(VTE_TERMINAL(widget), &color);
 			}
 		}
+#endif
 
 		/* Get custom tag attribute "cursor-background-color" */
 		if ((value = get_tag_attribute(attr, "cursor-background-color"))) {
@@ -298,6 +316,22 @@ void widget_terminal_fork_command(GtkWidget *widget, tag_attr *attr)
 #endif
 
 #if VTE_CHECK_VERSION(0,26,0)
+#if VTE_CHECK_VERSION(0,38,0)
+	retval = (vte_terminal_spawn_sync(VTE_TERMINAL(widget),
+		VTE_PTY_DEFAULT,
+		working_directory,
+		argv,
+		envv,
+		G_SPAWN_SEARCH_PATH,
+		NULL,
+		NULL,
+		&pid,
+		NULL,
+		&error));
+	if (!retval)
+		fprintf(stderr, "%s(): vte_terminal_spawn_sync(): %s\n",
+			__func__, error->message);
+#else
 	retval = (vte_terminal_fork_command_full(VTE_TERMINAL(widget),
 		VTE_PTY_DEFAULT,
 		working_directory,
@@ -311,6 +345,7 @@ void widget_terminal_fork_command(GtkWidget *widget, tag_attr *attr)
 	if (!retval)
 		fprintf(stderr, "%s(): vte_terminal_fork_command_full(): %s\n",
 			__func__, error->message);
+#endif
 #else
 	pid = (vte_terminal_fork_command(VTE_TERMINAL(widget),
 		argv[0],

--- a/src/widget_terminal.c
+++ b/src/widget_terminal.c
@@ -82,10 +82,10 @@ GtkWidget *widget_terminal_create(
 	gchar             tagattribute[256];
 	gchar            *value;
 	gint              width = -1, height = -1;
-#endif
 
 #if VTE_CHECK_VERSION(0,38,0)
 	PangoFontDescription *fontdesc;
+#endif
 #endif
 
 #ifdef DEBUG_TRANSITS


### PR DESCRIPTION
Had to remove support for "background-tint-color" and
"dim-foreground-color" because these were removed in vte 0.38

I do not claim to understand why vte-2.91.pc = Version: 0.48.4

Running './configure --enable-gtk3'
requires a newer version of vte than the default in Artful.
Running the following commands first will force using vte-2.91

export VTE_CFLAGS=`pkg-config --cflags "vte-2.91"`
export VTE_LIBS=`pkg-config --libs "vte-2.91"`

Should fix #50